### PR TITLE
Rename type props from type_ to _type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reason-native-base",
-  "version": "2.13.8-2",
+  "version": "2.13.8-3",
   "repository": "https://github.com/mduthilleul/reason-native-base.git",
   "license": "MIT",
   "keywords": [

--- a/src/NativeBase_Drawer.re
+++ b/src/NativeBase_Drawer.re
@@ -40,7 +40,7 @@ external make:
     ~tweenDuration: int=?,
     ~tweenEasing: string,
     ~tweenHandler: unit => unit,
-    ~type_: [@bs.string] [ `overlay | `static | `displace ] =?,
+    ~_type: [@bs.string] [ `overlay | `static | `displace ] =?,
     ~style: Style.t=?,
     ~testID: string=?,
     ~children: React.element=?

--- a/src/NativeBase_Icon.re
+++ b/src/NativeBase_Icon.re
@@ -12,7 +12,7 @@ external make:
     ~android: string=?,
     ~color: string=?,
     ~fontSize: int=?,
-    ~type_: [@bs.string] [
+    ~_type: [@bs.string] [
               | [@bs.as "AntDesign"] `ant_design
               | [@bs.as "Entypo"] `entype
               | [@bs.as "EvilIcons"] `evil_icons


### PR DESCRIPTION
By renaming "type" props from "type_" to "_type" we ensure that the compiled js files will contain the correct "type" props. Performed for Icon and Drawer modules.